### PR TITLE
semicolon in quotation

### DIFF
--- a/src/Directive.php
+++ b/src/Directive.php
@@ -184,7 +184,7 @@ class Directive extends Printable
     }
 
     private static function checkKeyValue($text) {
-        if (1 === preg_match('#^([a-zA-Z0-9._/+-]*)\s+([a-zA-Z0-9._/+-"\'].+)$#s', $text, $matches)) {
+        if (1 === preg_match('#^([a-zA-Z0-9._/+-]*)\s+(.+)$#s', $text, $matches)) {
             return array($matches[1], rtrim($matches[2]));
         }
         return false;

--- a/src/Directive.php
+++ b/src/Directive.php
@@ -87,13 +87,26 @@ class Directive extends Printable
      */
     public static function fromString(Text $configString)
     {
+        $quotation = false;
         $text = '';
         while (false === $configString->eof()) {
             $char = $configString->getChar();
-            if ('{' === $char) {
+            if (!$quotation && ('"' === $char || "'" === $char)) {
+                $quotation = $char;
+                $text .= $char;
+                $configString->inc();
+                continue;
+            }
+            if ($quotation && $quotation === $char) {
+                $quotation = false;
+                $text .= $char;
+                $configString->inc();
+                continue;
+            }
+            if ('{' === $char && !$quotation) {
                 return self::newDirectiveWithScope($text, $configString);
             }
-            if (';' === $char) {
+            if (';' === $char && !$quotation) {
                 return self::newDirectiveWithoutScope($text, $configString);
             }
             $text .= $char;
@@ -171,7 +184,7 @@ class Directive extends Printable
     }
 
     private static function checkKeyValue($text) {
-        if (1 === preg_match('#^([a-zA-Z0-9._/+-]*)\s+([^;{]+)$#', $text, $matches)) {
+        if (1 === preg_match('#^([a-zA-Z0-9._/+-]*)\s+([a-zA-Z0-9._/+-"\'].+)$#s', $text, $matches)) {
             return array($matches[1], rtrim($matches[2]));
         }
         return false;

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -225,6 +225,23 @@ class Scope extends Printable
 		return null;
 	}
 
+    /**
+     * returns all directives searched by key as an array, for example return all server
+     *
+     * @param string $key
+     * @return array
+     */
+	public function getAllDirectivesByKey($key) 
+	{
+        $reusult = array();
+		foreach($this->directives as $dir) {
+			if ($key == $dir->getName()) {
+				$reusult[] = $dir;
+			}
+		}
+		return $reusult;
+	}
+
 	public function getDirective($key)
 	{
 		$dir = null;


### PR DESCRIPTION
This patch solve the problem with semicolon (;) parsing if it in quotation (" or '). Fro example next line will be accepted

add_header Strict-Transport-Security "max-age=63072000; includeSubdomains";
